### PR TITLE
Fix PipeWire subsystem failing to capture and send audio

### DIFF
--- a/info.mumble.Mumble.yml
+++ b/info.mumble.Mumble.yml
@@ -15,6 +15,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --own-name=org.kde.StatusNotifierItem-2-2
   - --filesystem=home
+  - --filesystem=xdg-run/pipewire-0:ro
   - --env=LD_LIBRARY_PATH=/app/lib/mumble/:/app/lib
 separate-locales: false
 cleanup:


### PR DESCRIPTION
`pw_stream_connect` is failing in Mumble because it cannot connect to the `pipewire-0` socket, which it needs to be able to talk to PipeWire on the host. (Needs Mumble to be patched with https://github.com/mumble-voip/mumble/pull/5530 first to get the PipeWire subsystem to show up.)

This is [the same way EasyEffects does it](https://github.com/flathub/com.github.wwmm.easyeffects/blob/master/com.github.wwmm.easyeffects.yml#L13).

Related to #19.