### PR TITLE
fix: Specify build number

### DIFF
--- a/info.mumble.Mumble.yml
+++ b/info.mumble.Mumble.yml
@@ -88,6 +88,7 @@ modules:
       - -Dserver=OFF
       - -Doverlay=OFF
       - -Dplugins=OFF
+      - -DBUILD_NUMBER=230
     sources:
       - type: git
         url: https://github.com/mumble-voip/mumble/


### PR DESCRIPTION
- The build number specified the last part of the version number since v1.4.230
- Fixes #22