### PR TITLE
Update boost and poco

### DIFF
--- a/info.mumble.Mumble.yml
+++ b/info.mumble.Mumble.yml
@@ -31,8 +31,8 @@ modules:
   - name: boost
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2
-        sha256: 8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
+        url: https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0_rc1.tar.bz2
+        sha256: 71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa
 
     buildsystem: simple
     build-commands:
@@ -78,10 +78,12 @@ modules:
 
   - name: poco
     buildsystem: cmake-ninja
+    config-opts:
+       - -DPOCO_UNBUNDLED=ON
     sources:
       - type: archive
-        url: https://github.com/pocoproject/poco/archive/poco-1.11.1-release.tar.gz
-        sha256: 2412a5819a239ff2ee58f81033bcc39c40460d7a8b330013a687c8c0bd2b4ac0
+        url: https://github.com/pocoproject/poco/archive/poco-1.12.4-release.tar.gz
+        sha256: 71ef96c35fced367d6da74da294510ad2c912563f12cd716ab02b6ed10a733ef
     cleanup:
       - /include/
       - /bin/


### PR DESCRIPTION
Also switch poco to not bundling third party libraries, this is potentially easier for us to keep secure, as the freedesktop runtime will take care of updating these.