### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/info.mumble.Mumble.yml
+++ b/info.mumble.Mumble.yml
@@ -14,7 +14,6 @@ finish-args:
   - --own-name=net.sourceforge.mumble.mumble
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.* # This seems wrong, we should reconsider when https://github.com/flathub/flatpak-builder-lint/issues/66 is fixed
   - --filesystem=home
   - --filesystem=xdg-run/pipewire-0:ro
   - --env=LD_LIBRARY_PATH=/app/lib/mumble/:/app/lib


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/66#issuecomment-1386033025

Might require updating to 22.08 first.