### PR TITLE
fix: Remove home filesystem permission by default

### DIFF
--- a/info.mumble.Mumble.yml
+++ b/info.mumble.Mumble.yml
@@ -14,7 +14,6 @@ finish-args:
   - --own-name=net.sourceforge.mumble.mumble
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --filesystem=home
   - --filesystem=xdg-run/pipewire-0:ro
   - --env=LD_LIBRARY_PATH=/app/lib/mumble/:/app/lib
 separate-locales: false


### PR DESCRIPTION
- File selection for recording and attaching images in chats works through portals as discussed in #71.

I tested selecting a file for recording and attaching an image to a direct message with the home permission deactivated. 

Please note: There is one minor issue with removing the file permission: 
Mumble does remember the last location where you saved recordings to. This path persists even when Mumble is restarted. 
For me recording did still work after the next Mumble restart (without restarting my machine or session), but I'm not sure what would happen when I restarted the whole machine. I'll try this out as well so further steps can be discussed.